### PR TITLE
Compliant with c++11 + memory leak avoided

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.10)
 
 project(sockcanpp LANGUAGES CXX VERSION 1.00)
 set(TARGET_NAME sockcanpp)
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 11)
 
 include_directories(
     include/

--- a/include/CanDriver.hpp
+++ b/include/CanDriver.hpp
@@ -105,7 +105,7 @@ namespace sockcanpp {
             int32_t _socketFd; ///!< The CAN socket file descriptor
             int32_t _queueSize; ////!< The size of the message queue read by waitForMessages()
 
-            mutex* _lock; ///!< Mutex for thread-safety.
+            mutex _lock; ///!< Mutex for thread-safety.
 
             string _canInterface; ///!< The CAN interface used for communication (e.g. can0, can1, ...)
 

--- a/include/CanId.hpp
+++ b/include/CanId.hpp
@@ -72,8 +72,8 @@ namespace sockcanpp {
         public: // +++ Operators +++
 
 #pragma region "Implicit Cast Operators"
-        operator int16_t()  const { return isStandardFrameId() ? (int16_t)_identifier : throw system_error(error_code(0xbad'1d, generic_category()), "INVALID CAST: ID is extended or invalid!"); }
-        operator uint16_t() const { return isStandardFrameId() ? (uint16_t)_identifier : throw system_error(error_code(0xbad'1d, generic_category()), "INVALID CAST: ID is extended or invalid!"); }
+        operator int16_t()  const { return isStandardFrameId() ? (int16_t)_identifier : throw system_error(error_code(0xbad1d, generic_category()), "INVALID CAST: ID is extended or invalid!"); }
+        operator uint16_t() const { return isStandardFrameId() ? (uint16_t)_identifier : throw system_error(error_code(0xbad1d, generic_category()), "INVALID CAST: ID is extended or invalid!"); }
         operator int32_t()  const { return _identifier; }
         operator uint32_t() const { return _identifier; }
 #pragma endregion

--- a/include/CanMessage.hpp
+++ b/include/CanMessage.hpp
@@ -58,7 +58,7 @@ namespace sockcanpp {
 
             CanMessage(const CanId canId, const string frameData): _canIdentifier(canId), _frameData(frameData) {
                 if (frameData.size() > 8) {
-                    throw system_error(error_code(0xbad'd1c, generic_category()), "Payload too big!");
+                    throw system_error(error_code(0xbadd1c, generic_category()), "Payload too big!");
                 }
 
                 struct can_frame rawFrame;

--- a/src/CanDriver.cpp
+++ b/src/CanDriver.cpp
@@ -82,8 +82,7 @@ namespace sockcanpp {
         CanDriver(canInterface, canProtocol, 0 /* match all */, defaultSenderId) {}
 
     CanDriver::CanDriver(const string canInterface, const int32_t canProtocol, const int32_t filterMask, const CanId defaultSenderId):
-        _defaultSenderId(defaultSenderId), _canProtocol(canProtocol), _canInterface(canInterface), _canFilterMask(filterMask), _socketFd(-1),
-        _lock(new mutex()) {
+        _defaultSenderId(defaultSenderId), _canProtocol(canProtocol), _canInterface(canInterface), _canFilterMask(filterMask), _socketFd(-1) {
         initialiseSocketCan();
     }
 #pragma endregion
@@ -100,7 +99,7 @@ namespace sockcanpp {
     bool CanDriver::waitForMessages(milliseconds timeout) {
         if (_socketFd < 0) { throw InvalidSocketException("Invalid socket!", _socketFd); }
 
-        unique_lock<mutex> locky(*_lock);
+        unique_lock<mutex> locky(_lock);
 
         fd_set readFileDescriptors;
         timeval waitTime;
@@ -122,7 +121,7 @@ namespace sockcanpp {
     CanMessage CanDriver::readMessage() {
         if (_socketFd < 0) { throw InvalidSocketException("Invalid socket!", _socketFd); }
 
-        unique_lock<mutex> locky(*_lock);
+        unique_lock<mutex> locky(_lock);
 
         int32_t readBytes = 0;
         can_frame canFrame;
@@ -147,7 +146,7 @@ namespace sockcanpp {
     int32_t CanDriver::sendMessage(const CanMessage message, bool forceExtended) {
         if (_socketFd < 0) { throw InvalidSocketException("Invalid socket!", _socketFd); }
 
-        unique_lock<mutex> locky(*_lock);
+        unique_lock<mutex> locky(_lock);
 
         int32_t bytesWritten = 0;
 
@@ -196,7 +195,7 @@ namespace sockcanpp {
     queue<CanMessage> CanDriver::readQueuedMessages() {
         if (_socketFd < 0) { throw InvalidSocketException("Invalid socket!", _socketFd); }
 
-        unique_lock<mutex> locky(*_lock);
+        unique_lock<mutex> locky(_lock);
 
         queue<CanMessage> messages;
 
@@ -213,7 +212,7 @@ namespace sockcanpp {
     void CanDriver::setCanFilterMask(const int32_t mask) {
         if (_socketFd < 0) { throw InvalidSocketException("Invalid socket!", _socketFd); }
 
-        unique_lock<mutex> locky(*_lock);
+        unique_lock<mutex> locky(_lock);
         can_filter canFilter;
 
         canFilter.can_id   = _defaultSenderId;
@@ -237,7 +236,7 @@ namespace sockcanpp {
      * @brief Initialises the underlying CAN socket.
      */
     void CanDriver::initialiseSocketCan() {
-        // unique_lock<mutex> locky(*_lock);
+        // unique_lock<mutex> locky(_lock);
 
         struct sockaddr_can address;
         struct ifreq ifaceRequest;
@@ -278,7 +277,7 @@ namespace sockcanpp {
      * @brief Closes the underlying CAN socket.
      */
     void CanDriver::uninitialiseSocketCan() {
-        unique_lock<mutex> locky(*_lock);
+        unique_lock<mutex> locky(_lock);
 
         if (_socketFd <= 0) { throw CanCloseException("Cannot close invalid socket!"); }
 


### PR DESCRIPTION
[~] CanDriver.hpp, CanId.hpp removed single quote separator, enabling C++11 compliance. [~] CanDriver.hpp, CanDriver.cpp std::mutex is no more a raw pointer, saving this memory leak.