### PR TITLE
fix extended id flag set even tough the id is below 2047

### DIFF
--- a/src/CanDriver.cpp
+++ b/src/CanDriver.cpp
@@ -163,7 +163,7 @@ namespace sockcanpp {
 
         auto canFrame = message.getRawFrame();
 
-        if (forceExtended || (message.getCanId() > CAN_SFF_MASK)) { canFrame.can_id |= CAN_EFF_FLAG; }
+        if (forceExtended || ((uint32_t)message.getCanId() > CAN_SFF_MASK)) { canFrame.can_id |= CAN_EFF_FLAG; }
 
         bytesWritten = write(_socketFd, (const void*)&canFrame, sizeof(canFrame));
 


### PR DESCRIPTION
Hi,
when i try it on the raspberry pi 4 using this line 

```
	struct can_frame frame;
	frame.can_id = _TransmitAddress & 0x7ff;
	frame.can_dlc = length;
	memcpy(frame.data, pData, length);
	std::cout<<frame.can_id<<'\n';
	sockcanpp::CanMessage messageToSend(frame);
	
	try
	{
		CanDriver::sendMessage(messageToSend,false);
	}
	catch (const std::exception &exc)
	{
		char buf[100];
		// this->spiFrameToString(buf, SPI_FRAME_SIZE);
		std::cerr << "CCanPort::Send warning, fail to sendMessage " << std::endl;
		std::cerr << exc.what();
		// std::cout << "warning, fail to sendMessage : " << buf << '\n';
	}

```

the transmit message id was 1507 ( 0x5E3 ) and it was below the standard id length ( 2047 )
but the sendmessage function incorrectly add the extended flag so the id was extended

![image](https://github.com/SimonCahill/libsockcanpp/assets/25162222/6101b877-dfe2-442e-b864-7972205d3ba2)

so my fix was just cast the message.getCanId() to uint32_t

![image](https://github.com/SimonCahill/libsockcanpp/assets/25162222/99d61d09-5318-4e27-a2c1-514add774b29)


