### PR TITLE
Fix wrong queue size while reading multiple frames.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ install(EXPORT ${PROJECT_NAME}Targets
 
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(
-    "${PROJECT_NAME}ConfigVersion.cmake"
+    "lib${PROJECT_NAME}ConfigVersion.cmake"
     VERSION ${${PROJECT_NAME}_VERSION}
     COMPATIBILITY AnyNewerVersion
 )

--- a/include/CanDriver.hpp
+++ b/include/CanDriver.hpp
@@ -61,9 +61,9 @@ namespace sockcanpp {
      */
     class CanDriver {
         public: // +++ Static +++
-            static const int32_t CAN_MAX_DATA_LENGTH; //!< The maximum amount of bytes allowed in a single CAN frame
-            static const int32_t CAN_SOCK_RAW; //!< The raw CAN protocol
-            static const int32_t CAN_SOCK_SEVEN; //!< A separate CAN protocol, used by certain embedded device OEMs.
+            static constexpr int32_t CAN_MAX_DATA_LENGTH = 8; //!< The maximum amount of bytes allowed in a single CAN frame
+            static constexpr int32_t CAN_SOCK_RAW        = CAN_RAW; //!< The raw CAN protocol
+            static constexpr int32_t CAN_SOCK_SEVEN      = 7; //!< A separate CAN protocol, used by certain embedded device OEMs.
 
         public: // +++ Constructor / Destructor +++
             CanDriver(const string& canInterface, const int32_t canProtocol, const CanId defaultSenderId = 0); //!< Constructor
@@ -130,7 +130,7 @@ namespace sockcanpp {
     template<typename... Args>
     string formatString(const string& format, Args... args)  {
         using std::unique_ptr;
-        auto stringSize = snprintf(NULL, 0, format.c_str(), args...) + 1; // +1 for \0
+        auto stringSize = snprintf(nullptr, 0, format.c_str(), args...) + 1; // +1 for \0
         unique_ptr<char[]> buffer(new char[stringSize]);
 
         snprintf(buffer.get(), stringSize, format.c_str(), args...);

--- a/include/CanDriver.hpp
+++ b/include/CanDriver.hpp
@@ -61,56 +61,56 @@ namespace sockcanpp {
      */
     class CanDriver {
         public: // +++ Static +++
-            static const int32_t CAN_MAX_DATA_LENGTH; ///!< The maximum amount of bytes allowed in a single CAN frame
-            static const int32_t CAN_SOCK_RAW; ///!< The raw CAN protocol
-            static const int32_t CAN_SOCK_SEVEN; ///!< A separate CAN protocol, used by certain embedded device OEMs.
+            static const int32_t CAN_MAX_DATA_LENGTH; //!< The maximum amount of bytes allowed in a single CAN frame
+            static const int32_t CAN_SOCK_RAW; //!< The raw CAN protocol
+            static const int32_t CAN_SOCK_SEVEN; //!< A separate CAN protocol, used by certain embedded device OEMs.
 
         public: // +++ Constructor / Destructor +++
-            CanDriver(const string canInterface, const int32_t canProtocol, const CanId defaultSenderId = 0); ///!< Constructor
-            CanDriver(const string canInterface, const int32_t canProtocol, const int32_t filterMask, const CanId defaultSenderId = 0);
-            CanDriver() {}
-            virtual ~CanDriver() { uninitialiseSocketCan(); } ///!< Destructor
+            CanDriver(const string& canInterface, const int32_t canProtocol, const CanId defaultSenderId = 0); //!< Constructor
+            CanDriver(const string& canInterface, const int32_t canProtocol, const int32_t filterMask, const CanId defaultSenderId = 0);
+            CanDriver() = default;
+            virtual ~CanDriver() { uninitialiseSocketCan(); } //!< Destructor
 
         public: // +++ Getter / Setter +++
-            CanDriver& setDefaultSenderId(const CanId id) { this->_defaultSenderId = id; return *this; } ///!< Sets the default sender ID
+            CanDriver& setDefaultSenderId(const CanId id) { this->_defaultSenderId = id; return *this; } //!< Sets the default sender ID
 
-            const CanId getDefaultSenderId() const { return this->_defaultSenderId; } ///!< Gets the default sender ID
+            CanId getDefaultSenderId() const { return this->_defaultSenderId; } //!< Gets the default sender ID
 
-            const int32_t getFilterMask() const { return this->_canFilterMask; } ///!< Gets the filter mask used by this instance
-            const int32_t getMessageQueueSize() const { return this->_queueSize; } ///!< Gets the amount of CAN messages found after last calling waitForMessages()
-            const int32_t getSocketFd() const { return this->_socketFd; } ///!< The socket file descriptor used by this instance.
+            int32_t getFilterMask() const { return this->_canFilterMask; } //!< Gets the filter mask used by this instance
+            int32_t getMessageQueueSize() const { return this->_queueSize; } //!< Gets the amount of CAN messages found after last calling waitForMessages()
+            int32_t getSocketFd() const { return this->_socketFd; } //!< The socket file descriptor used by this instance.
 
         public: // +++ I/O +++
-            virtual bool waitForMessages(milliseconds timeout = milliseconds(3000)); ///!< Waits for CAN messages to appear
+            virtual bool waitForMessages(milliseconds timeout = milliseconds(3000)); //!< Waits for CAN messages to appear
 
-            virtual CanMessage readMessage(); ///!< Attempts to read a single message from the bus
+            virtual CanMessage readMessage(); //!< Attempts to read a single message from the bus
 
-            virtual int32_t sendMessage(const CanMessage message, bool forceExtended = false); ///!< Attempts to send a single CAN message
-            virtual int32_t sendMessageQueue(queue<CanMessage> messages,
-                                     milliseconds delay = milliseconds(20), bool forceExtended = false); ///!< Attempts to send a queue of messages
+            virtual ssize_t sendMessage(const CanMessage& message, bool forceExtended = false); //!< Attempts to send a single CAN message
+            virtual ssize_t sendMessageQueue(queue<CanMessage> messages,
+                                     milliseconds delay = milliseconds(20), bool forceExtended = false); //!< Attempts to send a queue of messages
              
-            virtual queue<CanMessage> readQueuedMessages(); ///!< Attempts to read all queued messages from the bus
+            virtual queue<CanMessage> readQueuedMessages(); //!< Attempts to read all queued messages from the bus
 
-            virtual void setCanFilterMask(const int32_t mask); ///!< Attempts to set a new CAN filter mask to the BIOS
+            virtual void setCanFilterMask(const int32_t mask); //!< Attempts to set a new CAN filter mask to the BIOS
 
         protected: // +++ Socket Management +++
-            virtual void initialiseSocketCan(); ///!< Initialises socketcan
-            virtual void uninitialiseSocketCan(); ///!< Uninitialises socketcan
+            virtual void initialiseSocketCan(); //!< Initialises socketcan
+            virtual void uninitialiseSocketCan(); //!< Uninitialises socketcan
 
         private:
-            virtual CanMessage readMessageLock(bool const lock = true); ///!< readMessage deadlock guard
-            CanId _defaultSenderId; ///!< The ID to send messages with if no other ID was set.
+            virtual CanMessage readMessageLock(bool const lock = true); //!< readMessage deadlock guard
+            CanId _defaultSenderId; //!< The ID to send messages with if no other ID was set.
 
-            int32_t _canFilterMask; ///!< The bit mask used to filter CAN messages
-            int32_t _canProtocol; ///!< The protocol used when communicating via CAN
-            int32_t _socketFd; ///!< The CAN socket file descriptor
-            int32_t _queueSize; ////!< The size of the message queue read by waitForMessages()
+            int32_t _canFilterMask; //!< The bit mask used to filter CAN messages
+            int32_t _canProtocol; //!< The protocol used when communicating via CAN
+            int32_t _socketFd{-1}; //!< The CAN socket file descriptor
+            int32_t _queueSize{0}; ///!< The size of the message queue read by waitForMessages()
 
-            ///!< Mutex for thread-safety.
-            mutex _lock; 
-            mutex _lockSend; 
+            //!< Mutex for thread-safety.
+            mutex _lock{};
+            mutex _lockSend{}; 
 
-            string _canInterface; ///!< The CAN interface used for communication (e.g. can0, can1, ...)
+            string _canInterface; //!< The CAN interface used for communication (e.g. can0, can1, ...)
 
     };
 


### PR DESCRIPTION
Due to an error on my part, a wrong assumption was made about the behaviour of `select()`.
`select()` returns the number of read file descriptors, instead of the amount of frames ready to be read.

This bug is a typical case of not noticing it, because it seem(s/ed) to work.

Thank you for reporting this.

The code in this PR is currently **untested**.

Once tested, fixes issue 14.