### PR TITLE
Added support for string to CanId conversions (well init with string value)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,24 @@ option(BUILD_TESTS "Build the tests" OFF)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-set(CMAKE_CXX_STANDARD 11)
+option(sockcanpp_CONCEPT_SUPPORT "Allow higher level language support" ON)
+
+if (sockcanpp_CONCEPT_SUPPORT)
+    message(STATUS "Enabling support for higher level language features")
+    set(CMAKE_CXX_STANDARD 20)
+else()
+    set(CMAKE_CXX_STANDARD 11)
+endif()
+
+add_compile_options(
+    -Wall
+    -Werror
+    -Wpedantic
+)
+
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -g")
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O2 -s")
+
 include(GNUInstallDirs)
 
 if (BUILD_SHARED_LIBS STREQUAL "ON")

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ libsockcanpp is a socketcan wrapper library for C++, aimed to be easy to use wit
 
 ## Building
 
+> **C++11** SUPPORT:  
+> This library supports modern C++ features, such as concepts in certain places.
+> If your project cannot support C++20 features, you can force the C++ standard back by setting  
+> `-Dsockcanpp_CONCEPT_SUPPORT=OFF` in the command-line or `set(sockcanpp_CONCEPT_SUPPORT OFF CACHE BOOL "Force C++ standard back to 11")`  
+> in your CMakeLists.txt.
+
 libsockcanpp was designed with use in CMake projects, but it can also easily be integrated into existing Makefile projects, as long as cmake is present on the build system.
 
 1) clone the repository: `git clone https://github.com/SimonCahill/libsockcanpp.git`
@@ -26,6 +32,9 @@ libsockcanpp was designed with use in CMake projects, but it can also easily be 
 2) add the following to CMakeLists.txt
 ```cmake
 if (NOT TARGET sockcanpp)
+    # IF you need C++11 support:
+    # set(sockcanpp_CONCEPT_SUPPORT OFF CACHE BOOL "Force C++ standard back to 11")
+
     add_subdirectory(/path/to/libsockcanpprepo ${CMAKE_CURRENT_BUILD_DIR}/libsockcanpp)
 endif()
 

--- a/include/exceptions/CanException.hpp
+++ b/include/exceptions/CanException.hpp
@@ -38,19 +38,19 @@ namespace sockcanpp { namespace exceptions {
      */
     class CanException: public exception {
         public: // +++ Constructor / Destructor +++
-            CanException(string message, int32_t socket): _message(message), _socket(socket) {}
+            CanException(const string& message, int32_t socket): m_socket(socket), m_message(message) {}
             ~CanException() {}
 
         public: // +++ Overrides +++
-            const char* what() { return _message.c_str(); }
+            const char* what() { return m_message.c_str(); }
 
         public: // +++ Getter +++
-            const int32_t getSocket() const { return _socket; }
+            const int32_t getSocket() const { return m_socket; }
 
         private:
-            int32_t _socket;
+            int32_t m_socket;
 
-            string _message;
+            string m_message;
     };
 
 } /* exceptions */ } /* sockcanpp */

--- a/include/exceptions/InvalidSocketException.hpp
+++ b/include/exceptions/InvalidSocketException.hpp
@@ -38,19 +38,19 @@ namespace sockcanpp { namespace exceptions {
      */
     class InvalidSocketException: public exception {
         public: // +++ Constructor / Destructor +++
-            InvalidSocketException(string message, int32_t socket): _message(message), _socket(socket) {}
+            InvalidSocketException(const string& message, int32_t socket): m_socket(socket), m_message(message) {}
             ~InvalidSocketException() {}
 
         public: // +++ Overrides +++
-            const char* what() { return _message.c_str(); }
+            const char* what() { return m_message.c_str(); }
 
         public: // +++ Getter +++
-            const int32_t getSocket() const { return _socket; }
+            const int32_t getSocket() const { return m_socket; }
 
         private:
-            int32_t _socket;
+            int32_t m_socket;
 
-            string _message;
+            string m_message;
     };
 
 } /* exceptions */ } /* sockcanpp */

--- a/test/app/src/Main.cpp
+++ b/test/app/src/Main.cpp
@@ -50,14 +50,15 @@ int main(int32_t argCount, char** argValues) {
 
     if (argCount > 2) {
         for (int32_t i = 1; i < argCount; i++) {
-            if (argValues[i] == "--help" || argValues[i] == "-h") {
+            string arg{argValues[i]};
+            if (arg == "--help" || arg == "-h") {
                 printHelp(argValues[0]);
                 return 0;
-            } else if (argValues[i] == "-protocol") {
+            } else if (arg == "-protocol") {
                 desiredCanSocket = atoi(argValues[i + 1]);
                 i += 1;
                 continue;
-            } else if (argValues[i] == "-iface") {
+            } else if (arg == "-iface") {
                 canInterface = (argValues[i + 1]);
                 i += 1;
                 continue;
@@ -70,12 +71,12 @@ int main(int32_t argCount, char** argValues) {
     if (canInterface == "")
         canInterface = "can0";
 
-    CanDriver* canDriver;
+    CanDriver* canDriver{nullptr};
     try {
         canDriver = new CanDriver(canInterface, CAN_RAW);
     } catch (CanInitException& ex) {
         cerr << "An error occurred while initialising CanDriver: " << ex.what() << endl;
-        delete canDriver;
+        if (canDriver) { delete canDriver; }
         return -1;
     }
 

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.10)
 
 project(libsockcanpp_unittests LANGUAGES CXX VERSION 0.1)
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(GTest REQUIRED)

--- a/test/unit/src/CanId_Tests.cpp
+++ b/test/unit/src/CanId_Tests.cpp
@@ -14,6 +14,8 @@
 
 using sockcanpp::CanId;
 
+using std::string;
+
 TEST(CanIdTests, CanId_invalidId_ExpectFalse) {
     ASSERT_FALSE(CanId::isValidIdentifier(-1));
 }
@@ -276,3 +278,48 @@ TEST(CanIdTests, CanId_ArithmeticOperatorModuloEquals_ExpectTrue) {
     id %= 2;
     ASSERT_EQ(id, 1);
 }
+
+#if __cpp_concepts >= 201907
+
+TEST(CanIdTests, CanId_TestStringToCanIdConversion_ExpectTrue) {
+    string id{"0x123"};
+
+    EXPECT_NO_THROW(CanId canId(id));
+    EXPECT_NO_THROW(CanId canId{id});
+    EXPECT_NO_THROW(CanId canId = id; (void)canId;);
+    EXPECT_NO_THROW(CanId canId{"0x123"});
+
+    CanId canId(id);
+    ASSERT_EQ(canId, 0x123);
+}
+
+TEST(CanIdTests, CanId_TestStringToCanIdConversion_ExpectTrue_ExplicitCast) {
+    string id{"0x123"};
+
+    EXPECT_NO_THROW(CanId canId(static_cast<const char*>(id.c_str())));
+    EXPECT_NO_THROW(CanId canId = static_cast<const char*>(id.c_str()); (void)canId;);
+    EXPECT_NO_THROW(CanId canId = static_cast<const char*>(id.c_str()); (void)canId;);
+
+    CanId canId(static_cast<const char*>(id.c_str()));
+    ASSERT_EQ(canId, 0x123);
+}
+
+TEST(CanIdTests, CanId_TestStringToCanIdConversion_ExpectTrue_ImplicitCast) {
+    string id{"0x123"};
+
+    EXPECT_NO_THROW(CanId canId = id; (void)canId;);
+    EXPECT_NO_THROW(CanId canId = id; (void)canId;);
+
+    CanId canId = id;
+    ASSERT_EQ(canId, 0x123);
+}
+
+TEST(CanIdTests, CanId_TestStringToCanIdConversion_ExpectError) {
+    string id{"hello_world"};
+
+    EXPECT_THROW(CanId canId(id), std::invalid_argument);
+    EXPECT_THROW(CanId canId = id; (void)canId;, std::invalid_argument);
+    EXPECT_THROW(CanId canId = id; (void)canId;, std::invalid_argument);
+}
+
+#endif // __cpp_concepts >= 201907


### PR DESCRIPTION
This PR merges changes to the CanId type, which allow it to be instantiated with string types.

Due to the use of concepts, this PR also changes the minimum recommended language standard.

> **Notes:**  
> - C++11 is _still_ supported.  
> To retain C++11 mode, see README.