### PR TITLE
Fixed regression which caused higher-than-expected timeouts.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.23)
 
-project(sockcanpp LANGUAGES CXX VERSION 1.4.0)
+project(sockcanpp LANGUAGES CXX VERSION 1.4.1)
 
 option(BUILD_SHARED_LIBS "Build shared libraries (.so) instead of static ones (.a)" ON)
 option(BUILD_TESTS "Build the tests" OFF)

--- a/src/CanDriver.cpp
+++ b/src/CanDriver.cpp
@@ -106,7 +106,7 @@ namespace sockcanpp {
         unique_lock<mutex> locky(_lock);
 
         fd_set readFileDescriptors;
-        timeval waitTime{0, timeout.count()};
+        timeval waitTime{0, static_cast<suseconds_t>(timeout.count())};
 
         FD_ZERO(&readFileDescriptors);
         FD_SET(_socketFd, &readFileDescriptors);

--- a/src/CanDriver.cpp
+++ b/src/CanDriver.cpp
@@ -106,8 +106,7 @@ namespace sockcanpp {
         unique_lock<mutex> locky(_lock);
 
         fd_set readFileDescriptors;
-        timeval waitTime;
-        waitTime.tv_usec = timeout.count();
+        timeval waitTime{0, timeout.count()};
 
         FD_ZERO(&readFileDescriptors);
         FD_SET(_socketFd, &readFileDescriptors);


### PR DESCRIPTION
This PR fixes a regression introduced in 1.4.0 which caused higher than expected timeouts when waiting for messages on a given bus.