### PR TITLE
Bug fix & add support for joining filters.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.23)
 
-project(sockcanpp LANGUAGES CXX VERSION 1.4.1)
+project(sockcanpp LANGUAGES CXX VERSION 1.4.2)
 
 option(BUILD_SHARED_LIBS "Build shared libraries (.so) instead of static ones (.a)" ON)
 option(BUILD_TESTS "Build the tests" OFF)

--- a/include/CanDriver.hpp
+++ b/include/CanDriver.hpp
@@ -106,6 +106,7 @@ namespace sockcanpp {
              
             virtual queue<CanMessage>   readQueuedMessages(); //!< Attempts to read all queued messages from the bus
 
+            virtual void                joinCanFilters() const; //!< Configures the socket to join the CAN filters
             virtual void                setCanFilterMask(const int32_t mask, const CanId& filterId); //!< Attempts to set a new CAN filter mask to the interface
             virtual void                setCanFilters(const filtermap_t& filters); //!< Sets the CAN filters for the interface
             virtual void                setErrorFilter(const bool enabled = true) const; //!< Sets the error filter for the interface

--- a/include/CanDriver.hpp
+++ b/include/CanDriver.hpp
@@ -106,10 +106,14 @@ namespace sockcanpp {
              
             virtual queue<CanMessage>   readQueuedMessages(); //!< Attempts to read all queued messages from the bus
 
+        public: // +++ Socket Management +++
+            virtual void                allowCanFdFrames(const bool enabled = true) const; //!< Sets the CAN FD frame option for the interface
+            virtual void                allowCanXlFrames(const bool enabled = true) const; //!< Sets the CAN XL frame option for the interface
             virtual void                joinCanFilters() const; //!< Configures the socket to join the CAN filters
             virtual void                setCanFilterMask(const int32_t mask, const CanId& filterId); //!< Attempts to set a new CAN filter mask to the interface
             virtual void                setCanFilters(const filtermap_t& filters); //!< Sets the CAN filters for the interface
             virtual void                setErrorFilter(const bool enabled = true) const; //!< Sets the error filter for the interface
+            virtual void                setReceiveOwnMessages(const bool enabled = true) const; //!< Sets the receive own messages option for the interface
 
         protected: // +++ Socket Management +++
             virtual void                initialiseSocketCan(); //!< Initialises socketcan

--- a/include/CanDriver.hpp
+++ b/include/CanDriver.hpp
@@ -106,7 +106,9 @@ namespace sockcanpp {
 
         public: // +++ Socket Management +++
             virtual void                allowCanFdFrames(const bool enabled = true) const; //!< Sets the CAN FD frame option for the interface
+            #ifdef CANXL_XLF
             virtual void                allowCanXlFrames(const bool enabled = true) const; //!< Sets the CAN XL frame option for the interface
+            #endif // CANXL_XLF
             virtual void                joinCanFilters() const; //!< Configures the socket to join the CAN filters
             virtual void                setCanFilterMask(const int32_t mask, const CanId& filterId); //!< Attempts to set a new CAN filter mask to the interface
             virtual void                setCanFilters(const filtermap_t& filters); //!< Sets the CAN filters for the interface
@@ -137,8 +139,6 @@ namespace sockcanpp {
             string      _canInterface; //!< The CAN interface used for communication (e.g. can0, can1, ...)
             
     };
-
-    
 
     /**
      * @brief Formats a std string object.

--- a/include/CanDriver.hpp
+++ b/include/CanDriver.hpp
@@ -5,9 +5,7 @@
  * @version 0.1
  * @date 2020-07-01
  * 
- * @copyright Copyright (c) 2020
- *
- *  Copyright 2020 Simon Cahill
+ * @copyright Copyright (c) 2020-2025 Simon Cahill
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/include/CanId.hpp
+++ b/include/CanId.hpp
@@ -152,6 +152,15 @@ namespace sockcanpp {
         #endif // __cpp_concepts >= 201907
 
         constexpr CanId operator =(const int64_t val) { return operator =((canid_t)val); } //!< Assigns a 64-bit integer to this ID.
+
+        template<typename T>
+        constexpr CanId operator |=(const T x) { return m_identifier |= x.m_identifier; } //!< Performs a bitwise OR operation on this ID and another.
+
+        template<typename T>
+        constexpr CanId operator &=(const T x) { return m_identifier &= x.m_identifier; } //!< Performs a bitwise AND operation on this ID and another.
+
+        template<typename T>
+        constexpr CanId operator ^=(const T x) { return m_identifier ^= x.m_identifier; } //!< Performs a bitwise XOR operation on this ID and another.
 #pragma endregion
 
 #pragma region "Arithmetic Operators"

--- a/include/CanId.hpp
+++ b/include/CanId.hpp
@@ -5,9 +5,7 @@
  * @version 0.1
  * @date 2020-07-01
  * 
- * @copyright Copyright (c) 2020 Simon Cahill
- *
- *  Copyright 2020 Simon Cahill
+ * @copyright Copyright (c) 2020-2025 Simon Cahill
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/include/CanId.hpp
+++ b/include/CanId.hpp
@@ -154,13 +154,13 @@ namespace sockcanpp {
         constexpr CanId operator =(const int64_t val) { return operator =((canid_t)val); } //!< Assigns a 64-bit integer to this ID.
 
         template<typename T>
-        constexpr CanId operator |=(const T x) { return m_identifier |= x.m_identifier; } //!< Performs a bitwise OR operation on this ID and another.
+        constexpr CanId operator |=(const T x) { return m_identifier |= x; } //!< Performs a bitwise OR operation on this ID and another.
 
         template<typename T>
-        constexpr CanId operator &=(const T x) { return m_identifier &= x.m_identifier; } //!< Performs a bitwise AND operation on this ID and another.
+        constexpr CanId operator &=(const T x) { return m_identifier &= x; } //!< Performs a bitwise AND operation on this ID and another.
 
         template<typename T>
-        constexpr CanId operator ^=(const T x) { return m_identifier ^= x.m_identifier; } //!< Performs a bitwise XOR operation on this ID and another.
+        constexpr CanId operator ^=(const T x) { return m_identifier ^= x; } //!< Performs a bitwise XOR operation on this ID and another.
 #pragma endregion
 
 #pragma region "Arithmetic Operators"

--- a/include/CanMessage.hpp
+++ b/include/CanMessage.hpp
@@ -5,9 +5,7 @@
  * @version 0.1
  * @date 2020-07-01
  * 
- * @copyright Copyright (c) 2020 Simon Cahill
- *
- *  Copyright 2020 Simon Cahill
+ * @copyright Copyright (c) 2020-2025 Simon Cahill
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -57,14 +55,14 @@ namespace sockcanpp {
             CanMessage(const struct can_frame frame):
             _canIdentifier(frame.can_id), _frameData((const char*)frame.data, frame.can_dlc), _rawFrame(frame) { }
 
-            CanMessage(const CanId canId, const string frameData): _canIdentifier(canId), _frameData(frameData) {
-                if (frameData.size() > 8) {
+            CanMessage(const CanId canId, const string& frameData): _canIdentifier(canId), _frameData(frameData) {
+                if (frameData.size() > CAN_MAX_DLEN) {
                     throw system_error(error_code(0xbadd1c, generic_category()), "Payload too big!");
                 }
 
-                struct can_frame rawFrame;
+                struct can_frame rawFrame{};
                 rawFrame.can_id = canId;
-                memcpy(rawFrame.data, frameData.data(), frameData.size());
+                std::copy(frameData.begin(), frameData.end(), rawFrame.data);
                 rawFrame.can_dlc = frameData.size();
 
                 _rawFrame = rawFrame;

--- a/src/CanDriver.cpp
+++ b/src/CanDriver.cpp
@@ -5,10 +5,7 @@
  * @version 0.1
  * @date 2020-07-01
  *
- * @copyright Copyright (c) 2020 Simon Cahill
- *
- *
- *  Copyright 2020 Simon Cahill
+ * @copyright Copyright (c) 2020-2025 Simon Cahill
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/CanDriver.cpp
+++ b/src/CanDriver.cpp
@@ -269,6 +269,40 @@ namespace sockcanpp {
     }
 
     /**
+     * @brief Sets the CAN FD frame option for the interface.
+     * 
+     * This option allows the current driver instance to receive CAN FD frames.
+     * 
+     * @param enabled Whether or not to enable the CAN FD frame option.
+     */
+    void CanDriver::allowCanFdFrames(const bool enabled/* = true*/) const {
+        if (_socketFd < 0) { throw InvalidSocketException("Invalid socket!", _socketFd); }
+
+        int32_t canFdFrames = enabled ? 1 : 0;
+
+        if (setsockopt(_socketFd, SOL_CAN_RAW, CAN_RAW_FD_FRAMES, &canFdFrames, sizeof(canFdFrames)) == -1) {
+            throw CanInitException(formatString("FAILED to set CAN FD frames on socket %d! Error: %d => %s", _socketFd, errno, strerror(errno)));
+        }
+    }
+
+    /**
+     * @brief Sets the CAN XL option for the interface.
+     * 
+     * This option allows the current driver instance to send/receive CAN XL frames.
+     * 
+     * @param enabled Whether or not to enable the CAN XL option.
+     */
+    void CanDriver::allowCanXlFrames(const bool enabled/* = true*/) const {
+        if (_socketFd < 0) { throw InvalidSocketException("Invalid socket!", _socketFd); }
+
+        int32_t canXlFrames = enabled ? 1 : 0;
+
+        if (setsockopt(_socketFd, SOL_CAN_RAW, CAN_RAW_XL_FRAMES, &canXlFrames, sizeof(canXlFrames)) == -1) {
+            throw CanInitException(formatString("FAILED to set CAN XL frames on socket %d! Error: %d => %s", _socketFd, errno, strerror(errno)));
+        }
+    }
+
+    /**
      * @brief Configures the socket to join the CAN filters.
      * This is especially required, when using inverted CAN filters.
      * 
@@ -330,6 +364,23 @@ namespace sockcanpp {
         int32_t errorFilter = enabled ? 1 : 0;
 
         if (setsockopt(_socketFd, SOL_CAN_RAW, CAN_RAW_ERR_FILTER, &errorFilter, sizeof(errorFilter)) == -1) {
+            throw CanInitException(formatString("FAILED to set CAN error filter on socket %d! Error: %d => %s", _socketFd, errno, strerror(errno)));
+        }
+    }
+    
+    /**
+     * @brief Sets the receive own messages option for the associated CAN bus.
+     * 
+     * This option allows the socket to receive its own messages.
+     * 
+     * @param enabled Whether or not to enable the receive own messages option.
+     */
+    void CanDriver::setReceiveOwnMessages(const bool enabled) const {
+        if (_socketFd < 0) { throw InvalidSocketException("Invalid socket!", _socketFd); }
+
+        int32_t receiveOwnMessages = enabled ? 1 : 0;
+
+        if (setsockopt(_socketFd, SOL_CAN_RAW, CAN_RAW_RECV_OWN_MSGS, &receiveOwnMessages, sizeof(receiveOwnMessages)) == -1) {
             throw CanInitException(formatString("FAILED to set CAN error filter on socket %d! Error: %d => %s", _socketFd, errno, strerror(errno)));
         }
     }

--- a/src/CanDriver.cpp
+++ b/src/CanDriver.cpp
@@ -269,6 +269,22 @@ namespace sockcanpp {
     }
 
     /**
+     * @brief Configures the socket to join the CAN filters.
+     * This is especially required, when using inverted CAN filters.
+     * 
+     * Source: https://stackoverflow.com/a/57680496/2921426
+     */
+    void CanDriver::joinCanFilters() const {
+        if (_socketFd < 0) { throw InvalidSocketException("Invalid socket!", _socketFd); }
+
+        int32_t joinFilters = 1;
+
+        if (setsockopt(_socketFd, SOL_CAN_RAW, CAN_RAW_JOIN_FILTERS, &joinFilters, sizeof(joinFilters)) == -1) {
+            throw CanInitException(formatString("FAILED to join CAN filters on socket %d! Error: %d => %s", _socketFd, errno, strerror(errno)));
+        }
+    }
+
+    /**
      * @brief Attempts to set the filter mask for the associated CAN bus.
      *
      * @param mask The bit mask to apply.

--- a/src/CanDriver.cpp
+++ b/src/CanDriver.cpp
@@ -306,11 +306,11 @@ namespace sockcanpp {
         // Structured bindings only available with C++17
         #if __cplusplus >= 201703L
         for (const auto [id, filter] : filters) {
-            canFilters.push_back({id, filter});
+            canFilters.push_back({*id, filter});
         }
         #else
         for (const auto& filterPair : filters) {
-            canFilters.push_back({filterPair.first, filterPair.second});
+            canFilters.push_back({*filterPair.first, filterPair.second});
         }
         #endif
 

--- a/src/CanDriver.cpp
+++ b/src/CanDriver.cpp
@@ -282,6 +282,7 @@ namespace sockcanpp {
         }
     }
 
+    #ifdef CANXL_XLF
     /**
      * @brief Sets the CAN XL option for the interface.
      * 
@@ -294,10 +295,12 @@ namespace sockcanpp {
 
         int32_t canXlFrames = enabled ? 1 : 0;
 
+        
         if (setsockopt(_socketFd, SOL_CAN_RAW, CAN_RAW_XL_FRAMES, &canXlFrames, sizeof(canXlFrames)) == -1) {
             throw CanInitException(formatString("FAILED to set CAN XL frames on socket %d! Error: %d => %s", _socketFd, errno, strerror(errno)));
         }
     }
+    #endif // CANXL_XLF
 
     /**
      * @brief Configures the socket to join the CAN filters.


### PR DESCRIPTION
This PR merges a new (non-breaking) feature, some minor QoL updates and a bug fix.

# Bug fix:  
First things first: the bug fix.  
This bug was introduced in #20.

The bug in question is an error when applying inverted CAN filters.
Instead of passing the unadulerated CAN ID to the socket, the masked ID was passed, completely nullifying the `CAN_INV_FILTER` flag.

# New feature:
When applying inverted filters, it is necessary to apply `CAN_RAW_JOIN_FILTERS`.
CanDriver now supports this via the new `joinCanFilters()` function.

# QoL updates:
`CanId` now supports bitwise assignments.