### PR TITLE
Support interfaces like vcan that don't support FIONREAD.

### DIFF
--- a/include/CanDriver.hpp
+++ b/include/CanDriver.hpp
@@ -131,6 +131,7 @@ namespace sockcanpp {
             int32_t     _canProtocol; //!< The protocol used when communicating via CAN
             int32_t     _socketFd{-1}; //!< The CAN socket file descriptor
             int32_t     _queueSize{0}; ///!< The size of the message queue read by waitForMessages()
+            bool        _canReadQueueSize{true}; ///!< Is the queue size available
 
             //!< Mutex for thread-safety.
             mutex       _lock{};


### PR DESCRIPTION
Some interfaces - and yes, vcan, I'm looking at you - don't support FIONREAD. Nor does MSG_TRUNC seem to work, so there's no way to find the amount of data waiting on the interface. So at present `_queueSize` is always zero, and `readQueuedMessages()` never returns waiting messages.

Attempt a minimally invasive workaround by noting the ioctl failure and on those sockets doing an uncounted read from the interface inside `readQueuedMessages()`. Users relying on `getQueueMessageSize()` to say something consistent will be sadly disappointed. Possibly, therefore, a better fix would be to read messages into a queue inside `waitForMessages()` and rework `readMessage()` and `readQueuedMessages()` to work with that queue. That, though, is a rather larger and riskier change.