### PR TITLE
Added support for error detection

### DIFF
--- a/include/CanId.hpp
+++ b/include/CanId.hpp
@@ -31,6 +31,7 @@
 #include <cmath>
 #include <exception>
 #include <linux/can.h>
+#include <linux/can/error.h>
 #include <system_error>
 
 #if __cpp_concepts >= 201907
@@ -269,13 +270,25 @@ namespace sockcanpp {
             }
 
         public: // +++ Getters +++
-            constexpr bool hasErrorFrameFlag() const { return isErrorFrame(m_identifier); } //!< Indicates whether or not this ID is an error frame.
-            constexpr bool hasRtrFrameFlag() const { return isRemoteTransmissionRequest(m_identifier); } //!< Indicates whether or not this ID is a remote transmission request.
-            constexpr bool isStandardFrameId() const { return !isExtendedFrame(m_identifier); } //!< Indicates whether or not this ID is a standard frame ID.
-            constexpr bool isExtendedFrameId() const { return isExtendedFrame(m_identifier); } //!< Indicates whether or not this ID is an extended frame ID.
+            constexpr bool hasErrorFrameFlag()  const { return isErrorFrame(m_identifier); } //!< Indicates whether or not this ID is an error frame.
+            constexpr bool hasRtrFrameFlag()    const { return isRemoteTransmissionRequest(m_identifier); } //!< Indicates whether or not this ID is a remote transmission request.
+            constexpr bool isStandardFrameId()  const { return !isExtendedFrame(m_identifier); } //!< Indicates whether or not this ID is a standard frame ID.
+            constexpr bool isExtendedFrameId()  const { return isExtendedFrame(m_identifier); } //!< Indicates whether or not this ID is an extended frame ID.
 
         public: // +++ Equality Checks +++
             constexpr bool equals(const CanId& otherId) const { return m_identifier == otherId.m_identifier; } //!< Compares this ID to another.
+
+        public: // +++ Error Frame Handling +++
+            constexpr bool hasBusError()            const { return hasErrorFrameFlag() && (m_identifier & CAN_ERR_BUSERROR); } //!< Checks if this ID has a bus error.
+            constexpr bool hasBusOffError()         const { return hasErrorFrameFlag() && (m_identifier & CAN_ERR_BUSOFF); } //!< Checks if this ID has a bus-off error.
+            constexpr bool hasControllerProblem()   const { return hasErrorFrameFlag() && (m_identifier & CAN_ERR_CRTL); } //!< Checks if this ID has a controller problem.
+            constexpr bool hasControllerRestarted() const { return hasErrorFrameFlag() && (m_identifier & CAN_ERR_RESTARTED); } //!< Checks if this ID has a controller restarted error.
+            constexpr bool hasErrorCounter()        const { return hasErrorFrameFlag() && (m_identifier & CAN_ERR_CNT); } //!< Checks if this ID has an error counter.
+            constexpr bool hasLostArbitration()     const { return hasErrorFrameFlag() && (m_identifier & CAN_ERR_LOSTARB); } //!< Checks if this ID has lost arbitration.
+            constexpr bool hasProtocolViolation()   const { return hasErrorFrameFlag() && (m_identifier & CAN_ERR_PROT); } //!< Checks if this ID has a protocol violation.
+            constexpr bool hasTransceiverStatus()   const { return hasErrorFrameFlag() && (m_identifier & CAN_ERR_TRX); } //!< Checks if this ID has a transceiver status error.
+            constexpr bool missingAckOnTransmit()   const { return hasErrorFrameFlag() && (m_identifier & CAN_ERR_ACK); } //!< Checks if this ID is missing an ACK on transmit.
+            constexpr bool isTxTimeout()            const { return hasErrorFrameFlag() && (m_identifier & CAN_ERR_TX_TIMEOUT); } //!< Checks if this ID is a transmission timeout error frame.
 
         private: // +++ Variables +++
             uint32_t m_identifier = 0;

--- a/include/CanMessage.hpp
+++ b/include/CanMessage.hpp
@@ -42,6 +42,9 @@
 //      LOCAL  INCLUDES     //
 //////////////////////////////
 #include "CanId.hpp"
+#include "can_errors/CanControllerError.hpp"
+#include "can_errors/CanProtocolError.hpp"
+#include "can_errors/CanTransceiverError.hpp"
 
 namespace sockcanpp {
 
@@ -145,6 +148,26 @@ namespace sockcanpp {
             [[nodiscard]] constexpr bool isStandardFrameId() const noexcept { return m_canIdentifier.isStandardFrameId(); } //!< Checks if the CAN message has a standard frame ID.
 
             [[nodiscard]] constexpr bool isExtendedFrameId() const noexcept { return m_canIdentifier.isExtendedFrameId(); } //!< Checks if the CAN message has an extended frame ID.
+
+        public: // +++ Error Frame Handling +++
+            constexpr bool hasBusError()            const { return m_canIdentifier.hasBusError();               }
+            constexpr bool hasBusOffError()         const { return m_canIdentifier.hasBusOffError();            }
+            constexpr bool hasControllerProblem()   const { return m_canIdentifier.hasControllerProblem();      }
+            constexpr bool hasControllerRestarted() const { return m_canIdentifier.hasControllerRestarted();    }
+            constexpr bool hasErrorCounter()        const { return m_canIdentifier.hasErrorCounter();           }
+            constexpr bool hasLostArbitration()     const { return m_canIdentifier.hasLostArbitration();        }
+            constexpr bool hasProtocolViolation()   const { return m_canIdentifier.hasProtocolViolation();      }
+            constexpr bool hasTransceiverStatus()   const { return m_canIdentifier.hasTransceiverStatus();      }
+            constexpr bool missingAckOnTransmit()   const { return m_canIdentifier.missingAckOnTransmit();      }
+            constexpr bool isTxTimeout()            const { return m_canIdentifier.isTxTimeout();               }
+
+        public: // +++ Errors +++
+            can_errors::ControllerError     getControllerError()    const { return can_errors::ControllerError::fromErrorCode(static_cast<can_errors::ControllerErrorCode>(m_rawFrame.data[1])); }
+            can_errors::ProtocolError       getProtocolError()      const { return can_errors::ProtocolError::fromErrorCode(static_cast<can_errors::ProtocolErrorCode>(m_rawFrame.data[2]), static_cast<can_errors::ProtocolErrorLocation>(m_rawFrame.data[3])); }
+            can_errors::TransceiverError    getTransceiverError()   const { return can_errors::TransceiverError::fromErrorCode(static_cast<can_errors::TransceiverErrorCode>(m_rawFrame.data[4])); }
+            size_t              getTxErrorCounter()     const { return m_rawFrame.data[6]; }
+            size_t              getRxErrorCounter()     const { return m_rawFrame.data[7]; }
+            uint8_t             arbitrationLostInBit()  const { return m_rawFrame.data[0]; }
 
         public: // +++ Equality Checks +++
             bool                operator==(const CanMessageT& other) const noexcept {

--- a/include/CanXLMessage.hpp
+++ b/include/CanXLMessage.hpp
@@ -1,0 +1,82 @@
+/**
+ * @file CanXLMessage.hpp
+ * @author Simon Cahill (contact@simonc.eu)
+ * @brief Contains the implementation of a CAN message representation in C++.
+ * @version 0.1
+ * @date 2025-03-25
+ * 
+ * @copyright Copyright (c) 2020-2025 Simon Cahill
+ * 
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef LIBSOCKCANPP_INCLUDE_CANXLMESSAGE_HPP
+#define LIBSOCKCANPP_INCLUDE_CANXLMESSAGE_HPP
+
+//////////////////////////////
+//      SYSTEM INCLUDES     //
+//////////////////////////////
+#include <linux/can.h>
+
+#include <cstring>
+#include <exception>
+#include <string>
+#include <system_error>
+#include <thread>
+
+//////////////////////////////
+//      LOCAL  INCLUDES     //
+//////////////////////////////
+#include "CanId.hpp"
+
+namespace sockcanpp {
+
+    using std::error_code;
+    using std::generic_category;
+    using std::string;
+    using std::system_error;
+
+    /**
+     * @brief Represents a CAN message that was received.
+     */
+    class CanMessage {
+        public: // +++ Constructor / Destructor +++
+            CanMessage(const struct canxl_frame frame): _rawFrame(frame) { }
+
+            CanMessage(const CanId& priorityField, const CanId& acceptanceField, const string& frameData) {
+                if (frameData.size() > CANXL_MAX_DLEN) {
+                    throw system_error(error_code(0xbadd1c, generic_category()), "Payload too big!");
+                }
+
+                struct canxl_frame rawFrame{};
+
+                std::copy(frameData.begin(), frameData.end(), rawFrame.data);
+
+                rawFrame.len = frameData.size();
+                rawFrame.prio = static_cast<uint16_t>(priorityField); // Ensure the CanId is truncated to 11 bits
+                rawFrame.af = static_cast<uint32_t>(acceptanceField); // Ensure the CanId is truncated to 32 bits
+                rawFrame.flags |= CANXL_XLF; // Set the mandatory CAN XL frame flag
+                rawFrame.sdt = 0; // Set the SDU type to 0 (default)
+            }
+
+            virtual ~CanMessage() = default;
+
+        public: // +++ Getters +++
+
+        private:
+            struct canxl_frame _rawFrame;
+    };
+
+}
+
+#endif // LIBSOCKCANPP_INCLUDE_CANXLMESSAGE_HPP

--- a/include/EnumCheck.hpp
+++ b/include/EnumCheck.hpp
@@ -1,0 +1,41 @@
+/**
+ * @file EnumCheck.hpp
+ * @author Simon Cahill (contact@simonc.eu)
+ * @brief Contains the implementation og a constexpr enumeration value checker.
+ * @version 0.1
+ * @date 2025-03-25
+ * 
+ * The entirety of this code is copied from https://stackoverflow.com/a/33091821/2921426
+ * 
+ * @copyright Copyright (c) 2025 Simon Cahill.
+ */
+
+#ifndef LIBSOCKCANPP_INCLUDE_ENUMCHECK_HPP
+#define LIBSOCKCANPP_INCLUDE_ENUMCHECK_HPP
+
+namespace sockcanpp {
+
+    template<typename EnumType, EnumType... Values>
+    class EnumCheck;
+
+    template<typename EnumType>
+    class EnumCheck<EnumType> {
+        public:
+            template<typename IntType>
+            static bool constexpr is_value(IntType) { return false; }
+    };
+
+    template<typename EnumType, EnumType V, EnumType... Next>
+    class EnumCheck<EnumType, V, Next...> : private EnumCheck<EnumType, Next...> {
+        using super = EnumCheck<EnumType, Next...>;
+
+        public:
+            template<typename IntType>
+            static bool constexpr is_value(IntType v) {
+                return v == static_cast<IntType>(V) || super::is_value(v);
+            }
+    };
+
+}
+
+#endif // LIBSOCKCANPP_INCLUDE_ENUMCHECK_HPP

--- a/include/can_errors/CanControllerError.hpp
+++ b/include/can_errors/CanControllerError.hpp
@@ -1,0 +1,87 @@
+/**
+ * @file CanControllerError.hpp
+ * @author Simon Cahill (contact@simonc.eu)
+ * @brief Contains the definition of CAN controller error codes.
+ * @version 0.1
+ * @date 2025-08-05
+ * 
+ * @copyright Copyright (c) 2025 Simon Cahill and Contributors.
+ */
+
+#ifndef LIBSOCKCANPP_INCLUDE_CAN_ERRORS_CANCONTROLLERERROR_HPP
+#define LIBSOCKCANPP_INCLUDE_CAN_ERRORS_CANCONTROLLERERROR_HPP
+
+#include <cstdint>
+#include <string>
+
+#include <linux/can/error.h>
+
+#if __cplusplus >= 201703L
+namespace sockcanpp::can_errors {
+#else
+namespace sockcanpp { namespace can_errors {
+#endif // __cplusplus >= 201703L
+
+    using std::string;
+
+    /**
+     * @brief Contains a typesafe representation of CAN controller error codes.
+     */
+    enum class ControllerErrorCode: uint8_t {
+        UNSPECIFIED_ERROR   = CAN_ERR_CRTL_UNSPEC, //!< Unspecified error.
+        RECEIVE_OVERFLOW    = CAN_ERR_CRTL_RX_OVERFLOW, //!< Receive overflow error.
+        TRANSMIT_OVERFLOW   = CAN_ERR_CRTL_TX_OVERFLOW, //!< Transmit overflow error.
+        RECEIVE_WARNING     = CAN_ERR_CRTL_RX_WARNING, //!< Receive warning error.
+        TRANSMIT_WARNING    = CAN_ERR_CRTL_TX_WARNING, //!< Transmit warning error.
+        RECEIVE_PASSIVE     = CAN_ERR_CRTL_RX_PASSIVE, //!< Receive passive error.
+        TRANSMIT_PASSIVE    = CAN_ERR_CRTL_TX_PASSIVE, //!< Transmit passive error.
+        RECOVERED_ACTIVE    = CAN_ERR_CRTL_ACTIVE, //!< Recovered to active state.
+    };
+
+    struct ControllerError {
+        ControllerErrorCode errorCode;
+        string              errorMessage;
+
+        ControllerError(ControllerErrorCode code, const string& message): errorCode(code), errorMessage(message) { }
+
+        static ControllerError fromErrorCode(ControllerErrorCode code) {
+            switch (code) {
+                case ControllerErrorCode::UNSPECIFIED_ERROR:   return ControllerError(code, "Unspecified error");
+                case ControllerErrorCode::RECEIVE_OVERFLOW:    return ControllerError(code, "Receive overflow error");
+                case ControllerErrorCode::TRANSMIT_OVERFLOW:   return ControllerError(code, "Transmit overflow error");
+                case ControllerErrorCode::RECEIVE_WARNING:     return ControllerError(code, "Receive warning error");
+                case ControllerErrorCode::TRANSMIT_WARNING:    return ControllerError(code, "Transmit warning error");
+                case ControllerErrorCode::RECEIVE_PASSIVE:     return ControllerError(code, "Receive passive error");
+                case ControllerErrorCode::TRANSMIT_PASSIVE:    return ControllerError(code, "Transmit passive error");
+                case ControllerErrorCode::RECOVERED_ACTIVE:    return ControllerError(code, "Recovered to active state");
+                default:                                       return ControllerError(code, "Unknown error");
+            }
+        }
+    };
+
+#if __cplusplus >= 201703L
+} // namespace sockcanpp::can_errors
+#else
+} /* namespace can_errors */ } /* namespace sockcanpp */
+#endif // __cplusplus >= 201703L
+
+namespace std {
+
+    inline string to_string(sockcanpp::can_errors::ControllerErrorCode err) {
+        using sockcanpp::can_errors::ControllerErrorCode;
+        switch (err) {
+            case ControllerErrorCode::UNSPECIFIED_ERROR:   return "Unspecified error";
+            case ControllerErrorCode::RECEIVE_OVERFLOW:    return "Receive overflow error";
+            case ControllerErrorCode::TRANSMIT_OVERFLOW:   return "Transmit overflow error";
+            case ControllerErrorCode::RECEIVE_WARNING:     return "Receive warning error";
+            case ControllerErrorCode::TRANSMIT_WARNING:    return "Transmit warning error";
+            case ControllerErrorCode::RECEIVE_PASSIVE:     return "Receive passive error";
+            case ControllerErrorCode::TRANSMIT_PASSIVE:    return "Transmit passive error";
+            case ControllerErrorCode::RECOVERED_ACTIVE:    return "Recovered to active state";
+            default:                                       return "Unknown controller error";
+        }
+    }
+
+}
+
+#endif // LIBSOCKCANPP_INCLUDE_CAN_ERRORS_CANCONTROLLERERROR_HPP

--- a/include/can_errors/CanProtocolError.hpp
+++ b/include/can_errors/CanProtocolError.hpp
@@ -1,0 +1,160 @@
+/**
+ * @file CanProtocolError.hpp
+ * @author Simon Cahill (contact@simonc.eu)
+ * @brief Contains the definition of CAN protocol error codes.
+ * @version 0.1
+ * @date 2025-08-05
+ * 
+ * @copyright Copyright (c) 2025 Simon Cahill and Contributors.
+ */
+
+#ifndef LIBSOCKCANPP_INCLUDE_CAN_ERRORS_CANPROTOCOLERROR_HPP
+#define LIBSOCKCANPP_INCLUDE_CAN_ERRORS_CANPROTOCOLERROR_HPP
+
+#include <cstdint>
+#include <string>
+
+#include <linux/can/error.h>
+
+#if __cplusplus >= 201703L
+namespace sockcanpp::can_errors {
+#else
+namespace sockcanpp { namespace can_errors {
+#endif // __cplusplus >= 201703L
+
+    using std::string;
+
+    /**
+     * @brief Contains a typesafe representation of CAN protocol error codes.
+     */
+    enum class ProtocolErrorCode: uint8_t {
+        UNSPECIFIED_ERROR   = CAN_ERR_CRTL_UNSPEC,  //!< Unspecified error occurred.
+        SINGLE_BIT_ERROR    = CAN_ERR_PROT_BIT,     //!< A single bit error occurred.
+        FRAME_FORMAT_ERROR  = CAN_ERR_PROT_FORM,    //!< A frame format error occurred.
+        BIT_STUFFING_ERROR  = CAN_ERR_PROT_STUFF,   //!< A bit stuffing error occurred.
+        DOMINANT_BIT_FAIL   = CAN_ERR_PROT_BIT0,    //!< A dominant bit failure occurred.
+        RECESSIVE_BIT_FAIL  = CAN_ERR_PROT_BIT1,    //!< A recessive bit failure occurred.
+        OVERLOAD_ERROR      = CAN_ERR_PROT_OVERLOAD,//!< An overload error occurred.
+        ACTIVE_ERROR        = CAN_ERR_PROT_ACTIVE,  //!< An active error occurred.
+        TX_ERROR            = CAN_ERR_PROT_TX       //!< A transmission error occurred.
+    };
+
+    /**
+     * @brief Contains a typesafe representation of CAN protocol error locations.
+     */
+    enum class ProtocolErrorLocation: uint8_t {
+        UNSPECIFIED_LOCATION = CAN_ERR_PROT_LOC_UNSPEC,     //!< Unspecified location.
+        START_OF_FRAME       = CAN_ERR_PROT_LOC_SOF,        //!< Start of frame.
+        IDBIT_28_21          = CAN_ERR_PROT_LOC_ID28_21,    //!< ID bits 28 - 21 (SFF: 10 - 3)
+        IDBIT_20_18          = CAN_ERR_PROT_LOC_ID20_18,    //!< ID bits 20 - 18 (SFF: 2 - 0)
+        SUBSTITUTE_RTR       = CAN_ERR_PROT_LOC_SRTR,       //!< Substitute RTR bit.
+        IDENTIFIER_EXTENSION = CAN_ERR_PROT_LOC_IDE,        //!< Identifier extension bit.
+        IDBIT_17_13          = CAN_ERR_PROT_LOC_ID17_13,    //!< ID bits 17 - 13
+        IDBIT_12_05          = CAN_ERR_PROT_LOC_ID12_05,    //!< ID bits 12 - 05
+        IDBIT_04_00          = CAN_ERR_PROT_LOC_ID04_00,    //!< ID bits 04 - 00
+        REMOTE_TRANSMIT_REQ  = CAN_ERR_PROT_LOC_RTR,        //!< Remote transmit request bit.
+        RESERVED_BIT_1       = CAN_ERR_PROT_LOC_RES1,       //!< Reserved bit 1.
+        RESERVED_BIT_0       = CAN_ERR_PROT_LOC_RES0,       //!< Reserved bit 0.
+        DATA_LENGTH_CODE     = CAN_ERR_PROT_LOC_DLC,        //!< Data length code.
+        DATA_SECTION         = CAN_ERR_PROT_LOC_DATA,       //!< Data section.
+        CRC_SECTION          = CAN_ERR_PROT_LOC_CRC_SEQ,    //!< CRC section.
+        CRC_DELIMITER        = CAN_ERR_PROT_LOC_CRC_DEL,    //!< CRC delimiter.
+        ACK_SLOT             = CAN_ERR_PROT_LOC_ACK,        //!< ACK slot.
+        ACK_DELIMITER        = CAN_ERR_PROT_LOC_ACK_DEL,    //!< ACK delimiter.
+        END_OF_FRAME         = CAN_ERR_PROT_LOC_EOF,        //!< End of frame.
+        INTERMISSION         = CAN_ERR_PROT_LOC_INTERM,     //!< Intermission section.
+    };
+
+    struct ProtocolError {
+        ProtocolErrorCode       errorCode;
+        ProtocolErrorLocation   errorLocation;
+        string                  errorMessage;
+
+        ProtocolError(ProtocolErrorCode code, ProtocolErrorLocation location, const string& message): errorCode(code), errorLocation(location), errorMessage(message) { }
+
+        static ProtocolError fromErrorCode(ProtocolErrorCode code, ProtocolErrorLocation location) {
+            switch (code) {
+                case ProtocolErrorCode::UNSPECIFIED_ERROR:   return ProtocolError(code, location, "Unspecified error occurred");
+                case ProtocolErrorCode::SINGLE_BIT_ERROR:    return ProtocolError(code, location, "Single bit error occurred");
+                case ProtocolErrorCode::FRAME_FORMAT_ERROR:  return ProtocolError(code, location, "Frame format error occurred");
+                case ProtocolErrorCode::BIT_STUFFING_ERROR:  return ProtocolError(code, location, "Bit stuffing error occurred");
+                case ProtocolErrorCode::DOMINANT_BIT_FAIL:   return ProtocolError(code, location, "Dominant bit failure occurred");
+                case ProtocolErrorCode::RECESSIVE_BIT_FAIL:  return ProtocolError(code, location, "Recessive bit failure occurred");
+                case ProtocolErrorCode::OVERLOAD_ERROR:      return ProtocolError(code, location, "Overload error occurred");
+                case ProtocolErrorCode::ACTIVE_ERROR:        return ProtocolError(code, location, "Active error occurred");
+                case ProtocolErrorCode::TX_ERROR:            return ProtocolError(code, location, "Transmission error occurred");
+                default:                                     return ProtocolError(code, location, "Unknown error occurred");
+            }
+        }
+    };
+
+#if __cplusplus >= 201703L
+} // namespace sockcanpp::can_errors
+#else
+} /* namespace can_errors */ } /* namespace sockcanpp */
+#endif // __cplusplus >= 201703L
+
+namespace std {
+
+    inline string to_string(sockcanpp::can_errors::ProtocolErrorLocation loc) {
+        using sockcanpp::can_errors::ProtocolErrorLocation;
+        switch (loc) {
+            case ProtocolErrorLocation::UNSPECIFIED_LOCATION:   return "Unspecified location.";
+            case ProtocolErrorLocation::START_OF_FRAME:         return "Start of frame.";
+            case ProtocolErrorLocation::IDBIT_28_21:            return "ID bits 28 - 21 (SFF: 10 - 3)";
+            case ProtocolErrorLocation::IDBIT_20_18:            return "ID bits 20 - 18 (SFF: 2 - 0)";
+            case ProtocolErrorLocation::SUBSTITUTE_RTR:         return "Substitute RTR bit.";
+            case ProtocolErrorLocation::IDENTIFIER_EXTENSION:   return "Identifier extension bit.";
+            case ProtocolErrorLocation::IDBIT_17_13:            return "ID bits 17 - 13";
+            case ProtocolErrorLocation::IDBIT_12_05:            return "ID bits 12 - 05";
+            case ProtocolErrorLocation::IDBIT_04_00:            return "ID bits 04 - 00";
+            case ProtocolErrorLocation::REMOTE_TRANSMIT_REQ:    return "Remote transmit request bit.";
+            case ProtocolErrorLocation::RESERVED_BIT_1:         return "Reserved bit 1.";
+            case ProtocolErrorLocation::RESERVED_BIT_0:         return "Reserved bit 0.";
+            case ProtocolErrorLocation::DATA_LENGTH_CODE:       return "Data length code.";
+            case ProtocolErrorLocation::DATA_SECTION:           return "Data section.";
+            case ProtocolErrorLocation::CRC_SECTION:            return "CRC section.";
+            case ProtocolErrorLocation::CRC_DELIMITER:          return "CRC delimiter.";
+            case ProtocolErrorLocation::ACK_SLOT:               return "ACK slot.";
+            case ProtocolErrorLocation::ACK_DELIMITER:          return "ACK delimiter.";
+            case ProtocolErrorLocation::END_OF_FRAME:           return "End of frame.";
+            case ProtocolErrorLocation::INTERMISSION:           return "Intermission section.";
+            default:                                            return "Unknown location.";
+        }
+    }
+
+    inline string to_string(sockcanpp::can_errors::ProtocolErrorCode err) {
+        using sockcanpp::can_errors::ProtocolErrorCode;
+        switch (err) {
+            case ProtocolErrorCode::UNSPECIFIED_ERROR:   return "Unspecified error occurred";
+            case ProtocolErrorCode::SINGLE_BIT_ERROR:    return "Single bit error occurred";
+            case ProtocolErrorCode::FRAME_FORMAT_ERROR:  return "Frame format error occurred";
+            case ProtocolErrorCode::BIT_STUFFING_ERROR:  return "Bit stuffing error occurred";
+            case ProtocolErrorCode::DOMINANT_BIT_FAIL:   return "Dominant bit failure occurred";
+            case ProtocolErrorCode::RECESSIVE_BIT_FAIL:  return "Recessive bit failure occurred";
+            case ProtocolErrorCode::OVERLOAD_ERROR:      return "Overload error occurred";
+            case ProtocolErrorCode::ACTIVE_ERROR:        return "Active error occurred";
+            case ProtocolErrorCode::TX_ERROR:            return "Transmission error occurred";
+            default:                                     return "Unknown error occurred";
+        }
+    }
+
+    inline string to_string(sockcanpp::can_errors::ProtocolErrorCode err, sockcanpp::can_errors::ProtocolErrorLocation loc) {
+        using sockcanpp::can_errors::ProtocolErrorCode;
+        switch (err) {
+            case ProtocolErrorCode::UNSPECIFIED_ERROR:   return to_string(err) + " at " + to_string(loc);
+            case ProtocolErrorCode::SINGLE_BIT_ERROR:    return to_string(err) + " at " + to_string(loc);
+            case ProtocolErrorCode::FRAME_FORMAT_ERROR:  return to_string(err) + " at " + to_string(loc);
+            case ProtocolErrorCode::BIT_STUFFING_ERROR:  return to_string(err) + " at " + to_string(loc);
+            case ProtocolErrorCode::DOMINANT_BIT_FAIL:   return to_string(err) + " at " + to_string(loc);
+            case ProtocolErrorCode::RECESSIVE_BIT_FAIL:  return to_string(err) + " at " + to_string(loc);
+            case ProtocolErrorCode::OVERLOAD_ERROR:      return to_string(err) + " at " + to_string(loc);
+            case ProtocolErrorCode::ACTIVE_ERROR:        return to_string(err) + " at " + to_string(loc);
+            case ProtocolErrorCode::TX_ERROR:            return to_string(err) + " at " + to_string(loc);
+            default:                                     return to_string(err) + " at " + to_string(loc);
+        }
+    }
+
+}
+
+#endif // LIBSOCKCANPP_INCLUDE_CAN_ERRORS_CANPROTOCOLERROR_HPP

--- a/include/can_errors/CanTransceiverError.hpp
+++ b/include/can_errors/CanTransceiverError.hpp
@@ -1,0 +1,95 @@
+/**
+ * @file CanTransceiverError.hpp
+ * @author Simon Cahill (contact@simonc.eu)
+ * @brief Contains the definition of CAN transceiver error codes.
+ * @version 0.1
+ * @date 2025-08-05
+ * 
+ * @copyright Copyright (c) 2025 Simon Cahill and Contributors.
+ */
+
+#ifndef LIBSOCKCANPP_INCLUDE_CAN_ERRORS_CANTRANSCEIVERERROR_HPP
+#define LIBSOCKCANPP_INCLUDE_CAN_ERRORS_CANTRANSCEIVERERROR_HPP
+
+#include <cstdint>
+#include <string>
+
+#include <linux/can/error.h>
+
+#if __cplusplus >= 201703L
+namespace sockcanpp::can_errors {
+#else
+namespace sockcanpp { namespace can_errors {
+#endif // __cplusplus >= 201703L
+
+    using std::string;
+
+    /**
+     * @brief Contains a typesafe representation of CAN transceiver error codes.
+     */
+    enum class TransceiverErrorCode: uint8_t {
+                                                                    //                                  CANH CANL
+        UNSPECIFIED_ERROR       =   CAN_ERR_TRX_UNSPEC,             //!< Unspecified error.             0000 0000
+        CAN_HIGH_NO_WIRE        =   CAN_ERR_TRX_CANH_NO_WIRE,       //!< CANH no wire error.            0000 0100
+        CAN_HIGH_SHORT_TO_BAT   =   CAN_ERR_TRX_CANH_SHORT_TO_BAT,  //!< CANH short to battery error.   0000 0101
+        CAN_HIGH_SHORT_TO_VCC   =   CAN_ERR_TRX_CANH_SHORT_TO_VCC,  //!< CANH short to VCC error.       0000 0110
+        CAN_HIGH_SHORT_TO_GND   =   CAN_ERR_TRX_CANH_SHORT_TO_GND,  //!< CANH short to ground error.    0000 0111
+
+        CAN_LOW_NO_WIRE         =   CAN_ERR_TRX_CANL_NO_WIRE,       //!< CANL no wire error.            0100 0000
+        CAN_LOW_SHORT_TO_BAT    =   CAN_ERR_TRX_CANL_SHORT_TO_BAT,  //!< CANL short to battery error.   0101 0000
+        CAN_LOW_SHORT_TO_VCC    =   CAN_ERR_TRX_CANL_SHORT_TO_VCC,  //!< CANL short to VCC error.       0110 0000
+        CAN_LOW_SHORT_TO_GND    =   CAN_ERR_TRX_CANL_SHORT_TO_GND,  //!< CANL short to ground error.    0111 0000
+        CAN_LOW_SHORT_TO_HIGH   =   CAN_ERR_TRX_CANL_SHORT_TO_CANH, //!< CANL short to CANH error.      1000 0000
+    };
+
+    struct TransceiverError {
+        TransceiverErrorCode errorCode;
+        string              errorMessage;
+
+        TransceiverError(TransceiverErrorCode code, const string& message): errorCode(code), errorMessage(message) { }
+
+        static TransceiverError fromErrorCode(TransceiverErrorCode code) {
+            switch (code) {
+                case TransceiverErrorCode::UNSPECIFIED_ERROR:       return TransceiverError(code, "Unspecified error.");
+                case TransceiverErrorCode::CAN_HIGH_NO_WIRE:        return TransceiverError(code, "CANH no wire error.");
+                case TransceiverErrorCode::CAN_HIGH_SHORT_TO_BAT:   return TransceiverError(code, "CANH short to battery error.");
+                case TransceiverErrorCode::CAN_HIGH_SHORT_TO_VCC:   return TransceiverError(code, "CANH short to VCC error.");
+                case TransceiverErrorCode::CAN_HIGH_SHORT_TO_GND:   return TransceiverError(code, "CANH short to ground error.");
+                case TransceiverErrorCode::CAN_LOW_NO_WIRE:         return TransceiverError(code, "CANL no wire error.");
+                case TransceiverErrorCode::CAN_LOW_SHORT_TO_BAT:    return TransceiverError(code, "CANL short to battery error.");
+                case TransceiverErrorCode::CAN_LOW_SHORT_TO_VCC:    return TransceiverError(code, "CANL short to VCC error.");
+                case TransceiverErrorCode::CAN_LOW_SHORT_TO_GND:    return TransceiverError(code, "CANL short to ground error.");
+                case TransceiverErrorCode::CAN_LOW_SHORT_TO_HIGH:   return TransceiverError(code, "CANL short to CANH error.");
+                default:                                            return TransceiverError(code, "Unknown error.");
+            }
+        }
+    };
+
+#if __cplusplus >= 201703L
+} // namespace sockcanpp::can_errors
+#else
+} /* namespace can_errors */ } /* namespace sockcanpp */
+#endif // __cplusplus >= 201703L
+
+namespace std {
+
+    inline string to_string(sockcanpp::can_errors::TransceiverErrorCode err) {
+        using sockcanpp::can_errors::TransceiverErrorCode;
+        switch (err) {
+            case TransceiverErrorCode::UNSPECIFIED_ERROR:       return "Unspecified error.";
+            case TransceiverErrorCode::CAN_HIGH_NO_WIRE:        return "CANH no wire error.";
+            case TransceiverErrorCode::CAN_HIGH_SHORT_TO_BAT:   return "CANH short to battery error.";
+            case TransceiverErrorCode::CAN_HIGH_SHORT_TO_VCC:   return "CANH short to VCC error.";
+            case TransceiverErrorCode::CAN_HIGH_SHORT_TO_GND:   return "CANH short to ground error.";
+            case TransceiverErrorCode::CAN_LOW_NO_WIRE:         return "CANL no wire error.";
+            case TransceiverErrorCode::CAN_LOW_SHORT_TO_BAT:    return "CANL short to battery error.";
+            case TransceiverErrorCode::CAN_LOW_SHORT_TO_VCC:    return "CANL short to VCC error.";
+            case TransceiverErrorCode::CAN_LOW_SHORT_TO_GND:    return "CANL short to ground error.";
+            case TransceiverErrorCode::CAN_LOW_SHORT_TO_HIGH:   return "CANL short to CANH error.";
+            default:                                            return "Unknown error.";
+        }
+    }
+
+}
+
+#endif // LIBSOCKCANPP_INCLUDE_CAN_ERRORS_CANTRANSCEIVERERROR_HPP

--- a/src/CanDriver.cpp
+++ b/src/CanDriver.cpp
@@ -321,21 +321,7 @@ namespace sockcanpp {
             bool more{true};
 
             do {
-                ssize_t readBytes;
-                can_frame canFrame{};
-                readBytes = read(m_socketFd, &canFrame, sizeof(can_frame));
-                if (readBytes >= 0) {
-                    if (m_collectTelemetry) {
-                        // Read timestamp from the socket if available.
-                        messages.emplace(CanMessage{canFrame, readFrameTimestamp()});
-                    } else {
-                        messages.emplace(canFrame);
-                    }
-                } else if (errno == EAGAIN || errno == EWOULDBLOCK) {
-                    more = false;
-                } else {
-                    throw CanException(formatString("FAILED to read from CAN! Error: %d => %s", errno, strerror(errno)), m_socketFd);
-                }
+                readMessageLock(false); // Read a message without locking the mutex
             } while (more);
         }
 

--- a/test/unit/src/CanMessage_ErrorFrameTests.cpp
+++ b/test/unit/src/CanMessage_ErrorFrameTests.cpp
@@ -1,0 +1,125 @@
+/**
+ * @file CanMessage_ErrorFrameTests.cpp
+ * @author Simon Cahill (contact@simonc.eu)
+ * @brief Contains all the unit tests for the error frame handling in the CanMessage structure.
+ * @version 0.1
+ * @date 2025-08-05
+ * 
+ * @copyright Copyright (c) 2025 Simon Cahill and Contributors.
+ */
+
+#include <gtest/gtest.h>
+
+#include <CanMessage.hpp>
+
+using sockcanpp::CanId;
+using sockcanpp::CanMessage;
+using namespace sockcanpp::can_errors;
+
+using std::string;
+
+constexpr CanId g_testCanId(0x123);
+
+TEST(CanMessageErrorFrameTests, CanMessage_ErrorFrame_ExpectTxTimeout) {
+    CanMessage msg(CanId(CAN_ERR_FLAG | CAN_ERR_TX_TIMEOUT), "");
+
+    ASSERT_TRUE(msg.isTxTimeout());
+}
+
+TEST(CanMessageErrorFrameTests, CanMessage_ErrorFrame_ExpectLostArbitration_Bit1) {
+    CanMessage msg(CanId(CAN_ERR_FLAG | CAN_ERR_LOSTARB), "\x01");
+
+    ASSERT_TRUE(msg.hasLostArbitration());
+    ASSERT_EQ(msg.arbitrationLostInBit(), 1);
+}
+
+TEST(CanMessageErrorFrameTests, CanMessage_ErrorFrame_ExpectLostArbitration_Bit10) {
+    CanMessage msg(CanId(CAN_ERR_FLAG | CAN_ERR_LOSTARB), "\x0a");
+
+    ASSERT_TRUE(msg.hasLostArbitration());
+    ASSERT_EQ(msg.arbitrationLostInBit(), 10);
+}
+
+TEST(CanMessageErrorFrameTests, CanMessage_ErrorFrame_ExpectLostArbitration_Bit100) {
+    CanMessage msg(CanId(CAN_ERR_FLAG | CAN_ERR_LOSTARB), "\x64");
+
+    ASSERT_TRUE(msg.hasLostArbitration());
+    ASSERT_EQ(msg.arbitrationLostInBit(), 100);
+}
+
+TEST(CanMessageErrorFrameTests, CanMessage_ErrorFrame_ExpectLostArbitration_TestAllBits) {
+    for (uint8_t i = 0; i < 0xff; i++) {
+        CanMessage msg(CanId(CAN_ERR_FLAG | CAN_ERR_LOSTARB), string(1, i));
+
+        ASSERT_TRUE(msg.hasLostArbitration());
+        ASSERT_EQ(msg.arbitrationLostInBit(), i);
+    }
+}
+
+TEST(CanMessageErrorFrameTests, CanMessage_ErrorFrame_ControllerProblem_ExpectUnspecified) {
+    CanMessage msg(CanId(CAN_ERR_FLAG | CAN_ERR_CRTL), "\xff\x00");
+
+    ASSERT_TRUE(msg.hasControllerProblem());
+    ASSERT_EQ(msg.getControllerError().errorCode, ControllerErrorCode::UNSPECIFIED_ERROR);
+}
+
+TEST(CanMessageErrorFrameTests, CanMessage_ErrorFrame_ControllerProblem_ExpectRxOverflow) {
+    CanMessage msg(CanId(CAN_ERR_FLAG | CAN_ERR_CRTL), "\xff\x01");
+
+    ASSERT_TRUE(msg.hasControllerProblem());
+    ASSERT_EQ(msg.getControllerError().errorCode, ControllerErrorCode::RECEIVE_OVERFLOW);
+}
+
+TEST(CanMessageErrorFrameTests, CanMessage_ErrorFrame_ControllerProblem_ExpectTxOverflow) {
+    CanMessage msg(CanId(CAN_ERR_FLAG | CAN_ERR_CRTL), "\xff\x02");
+
+    ASSERT_TRUE(msg.hasControllerProblem());
+    ASSERT_EQ(msg.getControllerError().errorCode, ControllerErrorCode::TRANSMIT_OVERFLOW);
+}
+
+TEST(CanMessageErrorFrameTests, CanMessage_ErrorFrame_ControllerProblem_ExpectRxWarning) {
+    CanMessage msg(CanId(CAN_ERR_FLAG | CAN_ERR_CRTL), "\xff\x04");
+
+    ASSERT_TRUE(msg.hasControllerProblem());
+    ASSERT_EQ(msg.getControllerError().errorCode, ControllerErrorCode::RECEIVE_WARNING);
+}
+
+TEST(CanMessageErrorFrameTests, CanMessage_ErrorFrame_ControllerProblem_ExpectTxWarning) {
+    CanMessage msg(CanId(CAN_ERR_FLAG | CAN_ERR_CRTL), "\xff\x08");
+
+    ASSERT_TRUE(msg.hasControllerProblem());
+    ASSERT_EQ(msg.getControllerError().errorCode, ControllerErrorCode::TRANSMIT_WARNING);
+}
+
+TEST(CanMessageErrorFrameTests, CanMessage_ErrorFrame_ControllerProblem_ExpectRxPassive) {
+    CanMessage msg(CanId(CAN_ERR_FLAG | CAN_ERR_CRTL), "\xff\x10");
+
+    ASSERT_TRUE(msg.hasControllerProblem());
+    ASSERT_EQ(msg.getControllerError().errorCode, ControllerErrorCode::RECEIVE_PASSIVE);
+}
+
+TEST(CanMessageErrorFrameTests, CanMessage_ErrorFrame_ControllerProblem_ExpectTxPassive) {
+    CanMessage msg(CanId(CAN_ERR_FLAG | CAN_ERR_CRTL), "\xff\x20");
+
+    ASSERT_TRUE(msg.hasControllerProblem());
+    ASSERT_EQ(msg.getControllerError().errorCode, ControllerErrorCode::TRANSMIT_PASSIVE);
+}
+
+TEST(CanMessageErrorFrameTests, CanMessage_ErrorFrame_ControllerProblem_ExpectRecoveredActive) {
+    CanMessage msg(CanId(CAN_ERR_FLAG | CAN_ERR_CRTL), "\xff\x40");
+
+    ASSERT_TRUE(msg.hasControllerProblem());
+    ASSERT_EQ(msg.getControllerError().errorCode, ControllerErrorCode::RECOVERED_ACTIVE);
+}
+
+TEST(CanMessageErrorFrameTests, CanMessage_ErrorFrame_ProtocolError_ExpectCombinations) {
+    for (uint8_t i = 0; i < 0xff; i <<= 1) {
+        for (uint8_t j = 0; j < 0xff; j <<= 1) {
+            CanMessage msg(CanId(CAN_ERR_FLAG | CAN_ERR_PROT), string(1, i) + string(1, j));
+
+            ASSERT_TRUE(msg.hasProtocolViolation());
+            ASSERT_EQ(msg.getProtocolError().errorCode, static_cast<ProtocolErrorCode>(i));
+            ASSERT_EQ(msg.getProtocolError().errorLocation, static_cast<ProtocolErrorLocation>(j));
+        }
+    }
+}


### PR DESCRIPTION
Added initial support for CAN error detection.

This support needs to be activated by setting the error frame filter, using `setErrorFilter()`