### PR TITLE
Fixes #35

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.23)
 
-project(sockcanpp LANGUAGES CXX VERSION 1.7.1 DESCRIPTION "A simple C++ wrapper for the Linux SocketCAN API" HOMEPAGE_URL "https://github.com/simoncahill/libsockcanpp")
+project(sockcanpp LANGUAGES CXX VERSION 1.7.2 DESCRIPTION "A simple C++ wrapper for the Linux SocketCAN API" HOMEPAGE_URL "https://github.com/simoncahill/libsockcanpp")
 
 option(BUILD_SHARED_LIBS "Build shared libraries (.so) instead of static ones (.a)" ON)
 option(BUILD_TESTS "Build the tests" OFF)

--- a/include/CanDriver.hpp
+++ b/include/CanDriver.hpp
@@ -155,9 +155,9 @@ namespace sockcanpp {
             virtual void                setReceiveOwnMessages(const bool enabled = true) const; //!< Sets the receive own messages option for the interface
             virtual void                setReturnRelativeTimestamps(const bool enabled = true) { m_relativeTimestamps = enabled; }
 
-        protected: // +++ Socket Management +++
-            virtual void                initialiseSocketCan(); //!< Initialises socketcan
-            virtual void                uninitialiseSocketCan(); //!< Uninitialises socketcan
+        private: // +++ Socket Management +++
+            void                        initialiseSocketCan(); //!< Initialises socketcan
+            void                        uninitialiseSocketCan(); //!< Uninitialises socketcan
 
         private: // +++ Member Functions +++
             virtual CanMessage          readMessageLock(bool const lock = true); //!< readMessage deadlock guard


### PR DESCRIPTION
# Fixes #35 (665a05d)
Make socket management functions private in CanDriver.

The initialiseSocketCan and uninitialiseSocketCan methods in the CanDriver class have been changed from protected to private access. This restricts their usage to within the class itself, enforcing encapsulation.

# Changes
 - Changed access modifier of initialiseSocketCan from protected to private in include/CanDriver.hpp.
 - Changed access modifier of uninitialiseSocketCan from protected to private in include/CanDriver.hpp.

# Impact
 - Prevents derived classes from directly calling initialiseSocketCan and uninitialiseSocketCan.
 - This change enforces the intended usage of the socket management functions, restricting access to the CanDriver class itself.
 - No immediate breaking changes are apparent unless derived classes were incorrectly calling these methods directly.