### PR TITLE
Updated README to reflect changes made in PR #36

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,12 +89,6 @@ using sockcanpp::exceptions::CanException;
 int main() {
 
     CanDriver cDriver{"can0", CAN_RAW}; // No default sender ID
-    
-    try {
-        cDriver.initialiseSocketCan();
-    } catch (CanException& ex) {
-        // handle failure
-    }
 
     sendCanFrame(cDriver);
     sendMultipleFrames(cDriver);


### PR DESCRIPTION
## Updated README to reflect changes made in PR #36 (fa0d269)

README update: Removed try-catch block around `initialiseSocketCan`

The README.md file was updated to remove a try-catch block surrounding the `cDriver.initialiseSocketCan()` call within the `main` function example. This change likely reflects an update in how the `CanDriver` class handles initialization errors, potentially removing the need for explicit exception handling at that specific location.

### Changes
- Removed the `try...catch` block surrounding `cDriver.initialiseSocketCan()` in the main function example.
- Modified components/files: README.md

### Impact
- Behavioral changes: The example code no longer explicitly catches `CanException` during `CanDriver` initialization at that specific location. This might mean the exception is handled elsewhere or considered unrecoverable.
- The change reflects an update to code implemented in PR #36 (as indicated in the commit message).