### PR TITLE
Export can_errors headers and fix cmake install naming issue.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ install(TARGETS ${PROJECT_NAME}
 )
 
 install(EXPORT ${PROJECT_NAME}Targets
-    FILE ${PROJECT_NAME}Targets.cmake
+    FILE "lib${PROJECT_NAME}Targets.cmake"
     NAMESPACE ${PROJECT_NAME}::
     DESTINATION lib/cmake/${PROJECT_NAME}
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.23)
 
-project(sockcanpp LANGUAGES CXX VERSION 1.7.3 DESCRIPTION "A simple C++ wrapper for the Linux SocketCAN API" HOMEPAGE_URL "https://github.com/simoncahill/libsockcanpp")
+project(sockcanpp LANGUAGES CXX VERSION 1.7.4 DESCRIPTION "A simple C++ wrapper for the Linux SocketCAN API" HOMEPAGE_URL "https://github.com/simoncahill/libsockcanpp")
 
 option(BUILD_SHARED_LIBS "Build shared libraries (.so) instead of static ones (.a)" ON)
 option(BUILD_TESTS "Build the tests" OFF)

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -11,6 +11,9 @@ target_sources(${PROJECT_NAME}
         exceptions/CanException.hpp
         exceptions/CanInitException.hpp
         exceptions/InvalidSocketException.hpp
+        can_errors/CanControllerError.hpp
+        can_errors/CanProtocolError.hpp
+        can_errors/CanTransceiverError.hpp
 )
 
 if (TARGET sockcanpp_test)
@@ -25,5 +28,8 @@ if (TARGET sockcanpp_test)
             exceptions/CanException.hpp
             exceptions/CanInitException.hpp
             exceptions/InvalidSocketException.hpp
+            can_errors/CanControllerError.hpp
+            can_errors/CanProtocolError.hpp
+            can_errors/CanTransceiverError.hpp
     )
 endif()


### PR DESCRIPTION
1.export can_errors headers; 
2.add lib prefix in install cmd to match cmake/libsockcanppConfig.cmake
[include(${CMAKE_CURRENT_LIST_DIR}/libsockcanppTargets.cmake)](https://github.com/SimonCahill/libsockcanpp/blob/d4594382cb436b346ba76eafd5f7afd2f370f9c3/cmake/libsockcanppConfig.cmake#L3)